### PR TITLE
Update getInfoFromDs to support connecting to CA in a remote forest

### DIFF
--- a/PKI/CertificateServices/CertificateAuthority.cs
+++ b/PKI/CertificateServices/CertificateAuthority.cs
@@ -307,19 +307,18 @@ namespace PKI.CertificateServices {
         }
         void getInfoFromDs() {
             if (IsEnterprise && DsUtils.Ping()) {
-                if (_certConfig.GetField(CertConfigConstants.FieldCommonName) == Name) {
-                    String cn = "CN=" + _certConfig.GetField(CertConfigConstants.FieldSanitizedShortName) +
-                        ",CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration,DC=" +
-                        DsUtils.GetForestName().Replace(".", ",DC=");
-                    DistinguishedName = (String)DsUtils.GetEntryProperty(cn, DsUtils.PropDN);
-                    DisplayName = _certConfig.GetField(CertConfigConstants.FieldCommonName);
-                    try {
-                        String wes = _certConfig.GetField(CertConfigConstants.FieldEnrollmentServers);
-                        if (!String.IsNullOrEmpty(wes)) {
-                            getCesUri(wes);
-                        }
-                    } catch { }
-                }
+                string domain = (string) DsUtils.GetEntryProperty(String.Join(".", this.ComputerName.Split('.').Where((v, i) => i != 0)) + "/RootDSE", "rootDomainNamingContext");
+                String dn = "CN=" + this.Name +
+                    ",CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration," + domain;
+                DistinguishedName = dn;
+                DisplayName = (String)DsUtils.GetEntryProperty(dn, "DisplayName");
+                try {
+                    String wes  = (String)DsUtils.GetEntryProperty(dn, "msPKI-Enrollment-Servers");
+                    if (!String.IsNullOrEmpty(wes)) {
+                        getCesUri(wes);
+                    }
+                } catch { }
+                
             }
             if (String.IsNullOrEmpty(DisplayName)) { DisplayName = Name; }
         }


### PR DESCRIPTION
Removed the conditional statement on the 3rd line of the function as it seemed unneeded. Updated retrieval of forest name to query the domain of the CA and rootDomainNamingContext via the RootDSA using LDAP. Before this was assuming the forest to the be same of the user running the function. This would cause attempting to connect to a CA in a resource forest to fail if using the account in the forest for accounts. Updated displayName, enrollemtn servers to be retrieved via LDAP as it is published in AD and in my test worked better then using _certConfig.

Example of getting a CA in a remote forest in Powershell.
$ca = [PKI.CertificateServices.CertificateAuthority]::new('COMPUTER_NAME', 'CA_DISPLAYNAME');
$ca | Get-IssuedRequest