### PR TITLE
Fixed issue when ExtensionRawValue in Extension table is null or empty. #122

### DIFF
--- a/src/SysadminsLV.PKI.Win/Management/CertificateServices/Database/AdcsDbPropertyCollection.cs
+++ b/src/SysadminsLV.PKI.Win/Management/CertificateServices/Database/AdcsDbPropertyCollection.cs
@@ -171,7 +171,11 @@ public class AdcsDbPropertyCollection : IDictionary<String, Object> {
                 // add X509Extension object to the row.
                 AdcsDbExtensionFlags flags = (AdcsDbExtensionFlags)rawFlags;
                 Boolean critical = (flags & AdcsDbExtensionFlags.Critical) != 0;
-                var baseExtension = new X509Extension((String)name, Convert.FromBase64String((String)value), critical);
+                // extension value can be null, so need to handle this
+                Byte[] extensionRawData = String.IsNullOrEmpty(value as String)
+                    ? []
+                    : Convert.FromBase64String((String)value);
+                var baseExtension = new X509Extension((String)name, extensionRawData, critical);
                 try {
                     _dictionary["ExtensionObject"] = baseExtension.ConvertExtension();
                 } catch {


### PR DESCRIPTION
#### PR Classification
Bug fix to prevent runtime errors when handling null or empty extension values.

#### PR Summary
This pull request improves robustness by safely handling cases where certificate extension values are null or empty strings.
- AdcsDbPropertyCollection.cs: Added a check to use an empty byte array when the extension value is null or empty, preventing exceptions from Convert.FromBase64String.
